### PR TITLE
move all logic into reusable PONSO(tm)

### DIFF
--- a/KeyboardView.xcodeproj/project.pbxproj
+++ b/KeyboardView.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		8383ED8819EE11890090183D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8383ED8719EE11890090183D /* Images.xcassets */; };
 		8383ED8B19EE11890090183D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8383ED8919EE11890090183D /* LaunchScreen.xib */; };
 		8383EDA319EE1F620090183D /* milky_way@3x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8383EDA219EE1F620090183D /* milky_way@3x.jpg */; };
+		9659293F1B1C620600C241C9 /* BottomLayoutKeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9659293E1B1C620600C241C9 /* BottomLayoutKeyboardResponder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		8383ED8719EE11890090183D /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		8383ED8A19EE11890090183D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		8383EDA219EE1F620090183D /* milky_way@3x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "milky_way@3x.jpg"; sourceTree = "<group>"; };
+		9659293E1B1C620600C241C9 /* BottomLayoutKeyboardResponder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomLayoutKeyboardResponder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +58,7 @@
 		8383ED7D19EE11890090183D /* KeyboardView */ = {
 			isa = PBXGroup;
 			children = (
+				9659293E1B1C620600C241C9 /* BottomLayoutKeyboardResponder.swift */,
 				8383ED8019EE11890090183D /* AppDelegate.swift */,
 				8383ED8219EE11890090183D /* ViewController.swift */,
 				8383ED8419EE11890090183D /* Main.storyboard */,
@@ -147,6 +150,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8383ED8319EE11890090183D /* ViewController.swift in Sources */,
+				9659293F1B1C620600C241C9 /* BottomLayoutKeyboardResponder.swift in Sources */,
 				8383ED8119EE11890090183D /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KeyboardView/Base.lproj/Main.storyboard
+++ b/KeyboardView/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -53,11 +53,14 @@
                             <constraint firstItem="0ET-jL-SgU" firstAttribute="top" secondItem="ajZ-86-qPP" secondAttribute="bottom" id="xUN-zp-1BX"/>
                         </constraints>
                     </view>
-                    <connections>
-                        <outlet property="bottomLayoutConstraint" destination="Ip0-ZW-ezK" id="kap-85-Cp6"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+                <customObject id="BHG-le-hUL" customClass="BottomLayoutKeyboardResponder" customModule="KeyboardView" customModuleProvider="target">
+                    <connections>
+                        <outlet property="bottomLayoutConstraint" destination="Ip0-ZW-ezK" id="S5e-gt-aWm"/>
+                        <outlet property="view" destination="kh9-bI-dsS" id="Jck-JU-qPB"/>
+                    </connections>
+                </customObject>
             </objects>
             <point key="canvasLocation" x="-30" y="399"/>
         </scene>

--- a/KeyboardView/BottomLayoutKeyboardResponder.swift
+++ b/KeyboardView/BottomLayoutKeyboardResponder.swift
@@ -1,0 +1,53 @@
+//
+//  BottomLayoutKeyboardResponder.swift
+//  KeyboardView
+//
+//  Created by Sebastian Bean on 6/1/15.
+//  Copyright (c) 2015 Effortless Code. All rights reserved.
+//
+
+import UIKit
+
+class BottomLayoutKeyboardResponder: NSObject {
+    
+    @IBOutlet weak var view: UIView!
+    @IBOutlet weak var bottomLayoutConstraint: NSLayoutConstraint!
+    
+    // MARK: - Private
+    
+    func updateBottomLayoutConstraintWithNotification(notification: NSNotification) {
+        let userInfo = notification.userInfo!
+        
+        let animationDuration = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as! NSNumber).doubleValue
+        let keyboardEndFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as! NSValue).CGRectValue()
+        let convertedKeyboardEndFrame = view.convertRect(keyboardEndFrame, fromView: view.window)
+        let rawAnimationCurve = (notification.userInfo![UIKeyboardAnimationCurveUserInfoKey] as! NSNumber).unsignedIntValue << 16
+        let animationCurve = UIViewAnimationOptions.init(UInt(rawAnimationCurve))
+        
+        bottomLayoutConstraint.constant = CGRectGetMaxY(view.bounds) - CGRectGetMinY(convertedKeyboardEndFrame)
+        
+        UIView.animateWithDuration(animationDuration, delay: 0.0, options: .BeginFromCurrentState | animationCurve, animations: {
+            self.view.layoutIfNeeded()
+            }, completion: nil)
+    }
+    
+    // MARK: - Notifications
+    
+    func keyboardWillShowNotification(notification: NSNotification) {
+        updateBottomLayoutConstraintWithNotification(notification)
+    }
+    
+    func keyboardWillHideNotification(notification: NSNotification) {
+        updateBottomLayoutConstraintWithNotification(notification)
+    }
+    
+    override init() {
+        super.init()
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShowNotification:", name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillHideNotification:", name: UIKeyboardWillHideNotification, object: nil)
+    }
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillHideNotification, object: nil)
+    }
+}

--- a/KeyboardView/ViewController.swift
+++ b/KeyboardView/ViewController.swift
@@ -9,53 +9,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-    @IBOutlet weak var bottomLayoutConstraint: NSLayoutConstraint!
 
-    // MARK: - Lifecycle
-    
-    override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShowNotification:", name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillHideNotification:", name: UIKeyboardWillHideNotification, object: nil)
-    }
-    
-    override func viewWillDisappear(animated: Bool) {
-        super.viewWillDisappear(animated)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillHideNotification, object: nil)
-    }
-    
-
-    // MARK: - Notifications
-    
-    func keyboardWillShowNotification(notification: NSNotification) {
-        updateBottomLayoutConstraintWithNotification(notification)
-    }
-    
-    func keyboardWillHideNotification(notification: NSNotification) {
-        updateBottomLayoutConstraintWithNotification(notification)
-    }
-    
-    
-    // MARK: - Private
-    
-    func updateBottomLayoutConstraintWithNotification(notification: NSNotification) {
-        let userInfo = notification.userInfo!
-        
-        let animationDuration = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as NSNumber).doubleValue
-        let keyboardEndFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as NSValue).CGRectValue()
-        let convertedKeyboardEndFrame = view.convertRect(keyboardEndFrame, fromView: view.window)
-        let rawAnimationCurve = (notification.userInfo![UIKeyboardAnimationCurveUserInfoKey] as NSNumber).unsignedIntValue << 16
-        let animationCurve = UIViewAnimationOptions.init(UInt(rawAnimationCurve))
-        
-        bottomLayoutConstraint.constant = CGRectGetMaxY(view.bounds) - CGRectGetMinY(convertedKeyboardEndFrame)
-        
-        UIView.animateWithDuration(animationDuration, delay: 0.0, options: .BeginFromCurrentState | animationCurve, animations: {
-            self.view.layoutIfNeeded()
-            }, completion: nil)
-    }
-    
-    
     // MARK: - UITextFieldDelegate
     
     func textFieldShouldReturn(textField: UITextField) -> Bool {


### PR DESCRIPTION
Initially thought to move to superclass. Realized all logic was self contained and could be moved to it's own class, separate from VC.

Little small to be a pod, but very handy!
